### PR TITLE
point to main, not to master

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Deploy docs
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [main]
     tags:
       - "*"
 
@@ -16,10 +16,10 @@ jobs:
       - name: checks for the label
         id: label_step
         run: |
-          if [[ "${{ github.ref  }}" == "refs/heads/master" ]]; then
+          if [[ "${{ github.ref  }}" == "refs/heads/main" ]]; then
                 echo "version=latest" >> $GITHUB_OUTPUT
           fi
-          if [[ "${{ github.ref_type }}" == "branch" ]] && [[ "${{ github.ref  }}" != "refs/heads/master" ]]; then
+          if [[ "${{ github.ref_type }}" == "branch" ]] && [[ "${{ github.ref  }}" != "refs/heads/main" ]]; then
                 exit 1
           fi
           if [[ "${{ github.ref_type }}" == "tag" ]]; then


### PR DESCRIPTION
Fixes #10

The deploy docs action was not successful since we were checking against `master` branch instead of `main`.