### PR TITLE
Raising errors for missing M or nshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ token = "your-token"
 client = qibo_client.Client(token)
 
 # run the circuit
-job = client.run_circuit(circuit, nshots=1000, device="sim")
+job = client.run_circuit(circuit, nshots=1000, device="k2")
 result = job.result()
 print(result)
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ obtain the needed token to run computations on the cluster.
 
 The following snippet provides a basic usage example.
 Replace the `your-token` string with your user token received during the
-registration process.
+registration process. To check which devices are available with your account
+please visit the dashboard at [https://cloud.qibo.science/](https://cloud.qibo.science/).
 
 ```python
 import qibo
@@ -46,7 +47,8 @@ token = "your-token"
 client = qibo_client.Client(token)
 
 # run the circuit
-job = client.run_circuit(circuit, nshots=1000, device="k2")
+device = "device_name"
+job = client.run_circuit(circuit, nshots=1000, device=device)
 result = job.result()
 print(result)
 ```

--- a/src/qibo_client/qibo_client.py
+++ b/src/qibo_client/qibo_client.py
@@ -6,7 +6,6 @@ import dateutil
 import qibo
 import tabulate
 from packaging.version import Version
-from qibo.config import raise_error
 
 from . import constants
 from .config_logging import logger
@@ -68,8 +67,8 @@ class Client:
     def run_circuit(
         self,
         circuit: qibo.Circuit,
+        device: str,
         nshots: int = None,
-        device: str = "k2",
     ) -> T.Optional[
         T.Union[
             qibo.result.QuantumState,
@@ -83,7 +82,7 @@ class Client:
         :type circuit: Circuit
         :param nshots: number of shots, mandatory for non-simulation devices, defaults to `nshots=100` for simulation partitions
         :type nshots: int
-        :param device: the device to run the circuit on. Default device is `k2`
+        :param device: the device to run the circuit on.
         :type device: str
         :param wait_for_results: whether to let the client hang until server results are ready or not. Defaults to True.
         :type wait_for_results: bool
@@ -95,7 +94,7 @@ class Client:
         """
         self.check_client_server_qibo_versions()
         logger.info("Post new circuit on the server")
-        job = self._post_circuit(circuit, nshots, device)
+        job = self._post_circuit(circuit, device, nshots)
 
         logger.info("Job posted on server with pid %s", self.pid)
         logger.info(
@@ -108,8 +107,8 @@ class Client:
     def _post_circuit(
         self,
         circuit: qibo.Circuit,
+        device: str,
         nshots: int = None,
-        device: str = "k2",
     ) -> QiboJob:
         url = self.base_url + "/client/run_circuit/"
 

--- a/src/qibo_client/qibo_client.py
+++ b/src/qibo_client/qibo_client.py
@@ -81,7 +81,7 @@ class Client:
 
         :param circuit: the QASM representation of the circuit to run
         :type circuit: Circuit
-        :param nshots: number of shots, mandatory for non-simulation devices
+        :param nshots: number of shots, mandatory for non-simulation devices, defaults to `nshots=100` for simulation partitions
         :type nshots: int
         :param device: the device to run the circuit on. Default device is `k2`
         :type device: str
@@ -94,19 +94,6 @@ class Client:
         :rtype: Optional[QiboJobResult]
         """
         self.check_client_server_qibo_versions()
-
-        if device != "k2":
-            if len(circuit.measurements) == 0:
-                raise_error(
-                    RuntimeError,
-                    "No measurement found in the input circuit. Measurements are mandatory on non-simulation devices.",
-                )
-            elif nshots is None:
-                raise_error(
-                    RuntimeError,
-                    "No number of shots defined. The total number of shots has to be defined when running on non-simulation devices.",
-                )
-
         logger.info("Post new circuit on the server")
         job = self._post_circuit(circuit, nshots, device)
 
@@ -125,9 +112,6 @@ class Client:
         device: str = "k2",
     ) -> QiboJob:
         url = self.base_url + "/client/run_circuit/"
-
-        if nshots is None:
-            nshots = 100
 
         payload = {
             "token": self.token,

--- a/tests/test_qibo_client.py
+++ b/tests/test_qibo_client.py
@@ -17,12 +17,21 @@ TIMEOUT = 1
 
 
 class FakeCircuit:
+    def __init__(self, measurements: list[int] = None):
+        self._measurements = [] if measurements is None else measurements
+
     @property
     def raw(self):
         return "fakeCircuit"
 
+    @property
+    def measurements(
+        self,
+    ):
+        return self._measurements
 
-FAKE_CIRCUIT = FakeCircuit()
+
+FAKE_CIRCUIT = FakeCircuit([0, 1, 2])
 FAKE_NSHOTS = 10
 FAKE_DEVICE = "fakeDevice"
 FAKE_NUM_QUBITS = 8
@@ -333,3 +342,18 @@ class TestQiboClient:
         )
         expected_result._status = QiboJobStatus.QUEUED
         assert vars(result) == vars(expected_result)
+
+    def test_no_measurements_error(self, pass_version_check):
+        circuit = FakeCircuit()
+        with pytest.raises(
+            RuntimeError,
+            match="No measurement found in the input circuit. Measurements are mandatory on non-simulation devices.",
+        ):
+            job = self.obj.run_circuit(circuit, FAKE_NSHOTS, FAKE_DEVICE)
+
+    def test_no_nshots_error(self, pass_version_check):
+        with pytest.raises(
+            RuntimeError,
+            match="No number of shots defined. The total number of shots has to be defined when running on non-simulation devices.",
+        ):
+            job = self.obj.run_circuit(FAKE_CIRCUIT, None, FAKE_DEVICE)

--- a/tests/test_qibo_client.py
+++ b/tests/test_qibo_client.py
@@ -345,18 +345,3 @@ class TestQiboClient:
         )
         expected_result._status = QiboJobStatus.QUEUED
         assert vars(result) == vars(expected_result)
-
-    def test_no_measurements_error(self, pass_version_check):
-        circuit = FakeCircuit()
-        with pytest.raises(
-            RuntimeError,
-            match="No measurement found in the input circuit. Measurements are mandatory on non-simulation devices.",
-        ):
-            job = self.obj.run_circuit(circuit, FAKE_NSHOTS, FAKE_DEVICE)
-
-    def test_no_nshots_error(self, pass_version_check):
-        with pytest.raises(
-            RuntimeError,
-            match="No number of shots defined. The total number of shots has to be defined when running on non-simulation devices.",
-        ):
-            job = self.obj.run_circuit(FAKE_CIRCUIT, None, FAKE_DEVICE)

--- a/tests/test_qibo_client.py
+++ b/tests/test_qibo_client.py
@@ -148,19 +148,22 @@ class TestQiboClient:
 
         assert str(err.value) == message
 
-    def test_run_circuit_with_success(self, pass_version_check, caplog):
+    @pytest.mark.parametrize(
+        "device,nshots", [("k2", None), (FAKE_DEVICE, FAKE_NSHOTS)]
+    )
+    def test_run_circuit_with_success(self, pass_version_check, caplog, device, nshots):
         caplog.set_level(logging.INFO)
         endpoint = FAKE_URL + "/client/run_circuit/"
         response_json = {"pid": FAKE_PID}
         pass_version_check.add(responses.POST, endpoint, status=200, json=response_json)
 
-        job = self.obj.run_circuit(FAKE_CIRCUIT, FAKE_NSHOTS, FAKE_DEVICE)
+        job = self.obj.run_circuit(FAKE_CIRCUIT, nshots, device)
 
         assert job.pid == FAKE_PID
         assert job.base_url == FAKE_URL
         assert job.circuit == "fakeCircuit"
-        assert job.nshots == FAKE_NSHOTS
-        assert job.device == FAKE_DEVICE
+        assert job.nshots == nshots if nshots is not None else 100
+        assert job.device == device
         assert job._status is None
 
         expected_messages = [


### PR DESCRIPTION
As per title, errors are raised when running on hardware and either:
- no measurements are present in the circuit
- `nshots` is not defined

this should close #73 

At the moment I am just checking whether `device == "k2"`, but ideally it would be nice if each partition had a property, `simulation=True` for instance, doing the check on the node inside the job and returning an error response.