### PR TITLE
Coloring the `JobApiError` in red

### DIFF
--- a/src/qibo_client/exceptions.py
+++ b/src/qibo_client/exceptions.py
@@ -27,5 +27,5 @@ class JobApiError(Exception):
     def __init__(self, status_code: int, message: str):
         self.status_code = status_code
         self.message = message
-        self.displayed_message = f"[{self.status_code} Error] {self.message}"
+        self.displayed_message = f"\033[91m[{self.status_code} Error] {self.message}"
         super().__init__(self.displayed_message)

--- a/tests/test_qibo_client.py
+++ b/tests/test_qibo_client.py
@@ -126,7 +126,7 @@ class TestQiboClient:
         with pytest.raises(exceptions.JobApiError) as err:
             self.obj.run_circuit(FAKE_CIRCUIT, FAKE_DEVICE, FAKE_NSHOTS)
 
-        expected_message = f"[404 Error] {message}"
+        expected_message = f"\033[91m[404 Error] {message}"
         assert str(err.value) == expected_message
 
     def test_run_circuit_with_job_post_error(self, pass_version_check):

--- a/tests/test_qibo_job.py
+++ b/tests/test_qibo_job.py
@@ -204,7 +204,7 @@ class TestQiboJob:
         with pytest.raises(exceptions.JobApiError) as err:
             self.obj.refresh()
 
-        expected_message = f"[404 Error] {response_json['detail']}"
+        expected_message = f"\033[91m[404 Error] {response_json['detail']}"
         assert str(err.value) == expected_message
 
     @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,7 +52,7 @@ def test_get_request_with_404_error():
     with pytest.raises(exceptions.JobApiError) as err:
         utils.QiboApiRequest.get(endpoint)
 
-    expected_message = f"[{status_code} Error] {message}"
+    expected_message = f"\033[91m[{status_code} Error] {message}"
     assert str(err.value) == expected_message
 
 
@@ -87,5 +87,5 @@ def test_post_request_with_404_error():
     with pytest.raises(exceptions.JobApiError) as err:
         utils.QiboApiRequest.post(endpoint)
 
-    expected_message = f"[{status_code} Error] {message}"
+    expected_message = f"\033[91m[{status_code} Error] {message}"
     assert str(err.value) == expected_message


### PR DESCRIPTION
As per title. Other things might be considered to improve readability, not sure which though...
Probably the error messages could be improved, but `qibo-client` is not responsible for that, as the `JobApiError` just repeats the response received.