### PR TITLE
Reconstruct results from API snapshot instead of downloading tarball

### DIFF
--- a/examples/run_successful_job.py
+++ b/examples/run_successful_job.py
@@ -29,5 +29,6 @@ client = Client(token)
 # run the circuit
 start = time.time()
 job = client.run_circuit(circuit, device="tii-sim", project="personal", nshots=150)
-print(job.result())
+r = job.result()
+print(r.frequencies())
 print(f"Program done in {time.time() - start:.4f}s")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "qibo-client"
-version = "0.2.4"
+version = "0.3.0"
 description = "Qibo client interface."
 authors = ["The Qibo team"]
 license = "Apache License 2.0"

--- a/src/qibo_client/qibo_job.py
+++ b/src/qibo_client/qibo_job.py
@@ -135,11 +135,11 @@ class QiboJob:
         circuit = qibo.Circuit.from_dict(snapshot["circuit"])
         frequencies = snapshot.get("frequencies")
         if circuit.measurements:
-            qubits = circuit[-1].qubits
-            return qibo.result.MeasurementOutcome.from_frequencies(
+            qubits = circuit.measurements[-1].qubits
+            return qibo.result.MeasurementOutcomes.from_frequencies(
                 frequencies, qubits=qubits, nqubits=circuit.nqubits
             )
-        return qibo.result.MeasurementOutcome.from_frequencies(
+        return qibo.result.MeasurementOutcomes.from_frequencies(
             frequencies, nqubits=circuit.nqubits
         )
 

--- a/src/qibo_client/qibo_job.py
+++ b/src/qibo_client/qibo_job.py
@@ -1,13 +1,9 @@
 import importlib.metadata as im
-import tarfile
-import tempfile
 import time
 import typing as T
 from enum import Enum
-from pathlib import Path
 
 import qibo
-import requests
 from rich.live import Live
 
 version = im.version(__package__)
@@ -39,30 +35,6 @@ class QiboJobStatus(Enum):
     POSTPROCESSING = "postprocessing"
     SUCCESS = "success"
     ERROR = "error"
-
-
-def _write_stream_to_tmp_file(stream: T.Iterable) -> Path:
-    """Write chunk of bytes to temporary file."""
-    with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
-        for chunk in stream:
-            if chunk:
-                tmp_file.write(chunk)
-        archive_path = tmp_file.name
-    return Path(archive_path)
-
-
-def _extract_archive_to_folder(source_archive: Path, destination_folder: Path):
-    with tarfile.open(source_archive, "r:gz") as archive:
-        archive.extractall(destination_folder)
-
-
-def _save_and_unpack_stream_response_to_folder(
-    stream: T.Iterable, results_folder: Path
-):
-    """Save the stream to a given folder, then unpack."""
-    archive_path = _write_stream_to_tmp_file(stream)
-    _extract_archive_to_folder(archive_path, results_folder)
-    archive_path.unlink()
 
 
 # -----------------------------
@@ -149,43 +121,31 @@ class QiboJob:
     def result(
         self, wait: float = 0.5, verbose: bool = True
     ) -> T.Optional[qibo.result.QuantumState]:
-        """Poll server until completion, then download and return result."""
-        response, job_status = self._wait_for_response_to_get_request(wait, verbose)
-
-        # create the job results folder
-        self.results_folder = constants.RESULTS_BASE_FOLDER / self.pid
-        self.results_folder.mkdir(parents=True, exist_ok=True)
-
-        # Save the stream to disk
-        try:
-            _save_and_unpack_stream_response_to_folder(
-                response.iter_content(), self.results_folder
-            )
-        except tarfile.ReadError as err:
-            logger.error("Catched tarfile ReadError: %s", err)
-            logger.error(
-                "The received file is not a valid gzip archive, the result might "
-                "have to be inspected manually. Find the file at `%s`",
-                self.results_folder.as_posix(),
-            )
-            return None
+        """Poll server until completion, then reconstruct result from snapshot data."""
+        snapshot, job_status = self._wait_for_response_to_get_request(wait, verbose)
 
         if job_status == QiboJobStatus.ERROR:
-            out_log_path = self.results_folder / "stdout.log"
-            stdout = out_log_path.read_text() if out_log_path.is_file() else "-"
-            err_log_path = self.results_folder / "stderr.log"
-            stderr = err_log_path.read_text() if err_log_path.is_file() else "-"
             logger.error(
-                "Job exited with error\n\nStdout:\n%s\n\nStderr:\n%s", stdout, stderr
+                "Job exited with error\n\nStdout:\n%s\n\nStderr:\n%s",
+                snapshot.get("stdout", "-"),
+                snapshot.get("stderr", "-"),
             )
             return None
 
-        self.results_path = self.results_folder / "results.npy"
-        return qibo.result.load_result(self.results_path)
+        circuit = qibo.Circuit.from_dict(snapshot["circuit"])
+        frequencies = snapshot.get("frequencies")
+        if circuit.measurements:
+            qubits = circuit[-1].qubits
+            return qibo.result.MeasurementOutcome.from_frequencies(
+                frequencies, qubits=qubits, nqubits=circuit.nqubits
+            )
+        return qibo.result.MeasurementOutcome.from_frequencies(
+            frequencies, nqubits=circuit.nqubits
+        )
 
     def _wait_for_response_to_get_request(
         self, seconds_between_checks: T.Optional[int] = None, verbose: bool = True
-    ) -> T.Tuple[requests.Response, QiboJobStatus]:
+    ) -> T.Tuple[T.Dict, QiboJobStatus]:
         """Poll the job until completion; return (download_response, final_status)."""
         if seconds_between_checks is None:
             seconds_between_checks = constants.SECONDS_BETWEEN_CHECKS
@@ -210,7 +170,7 @@ class QiboJob:
 
         # Small wrapper to fetch status + live fields
         def _fetch_snapshot() -> (
-            tuple[QiboJobStatus, T.Optional[int], T.Optional[int | float]]
+            tuple[QiboJobStatus, T.Optional[int], T.Optional[int | float], T.Dict]
         ):
             payload = QiboApiRequest.get(
                 url, headers=self.headers, timeout=constants.TIMEOUT
@@ -218,11 +178,11 @@ class QiboJob:
             status = convert_str_to_job_status(payload["status"])
             qpos = payload.get("queue_position", payload.get("job_queue_position"))
             etd = payload.get("etd_seconds", payload.get("seconds_to_job_start"))
-            return status, qpos, etd
+            return status, qpos, etd, payload
 
         # --- Live (TTY) branch ---
         if use_live:
-            status0, qpos0, etd0 = _fetch_snapshot()
+            status0, qpos0, etd0, _ = _fetch_snapshot()
 
             # Compose a single renderable from named slots.
             # You can add more slots later (e.g., "header", "footer") without changing Live plumbing.
@@ -242,7 +202,7 @@ class QiboJob:
             ) as live:
                 start_ts = time.perf_counter()
                 while True:
-                    job_status, qpos, etd = _fetch_snapshot()
+                    job_status, qpos, etd, payload = _fetch_snapshot()
 
                     renderable = _render(job_status, qpos, etd)
                     if renderable is not None:
@@ -252,13 +212,6 @@ class QiboJob:
 
                     if job_status in (QiboJobStatus.SUCCESS, QiboJobStatus.ERROR):
                         elapsed = time.perf_counter() - start_ts
-
-                        # Download first so that the final banner is the *last* thing shown
-                        response = QiboApiRequest.get(
-                            self.base_url + f"/api/jobs/{self.pid}/download/",
-                            headers=self.headers,
-                            timeout=constants.TIMEOUT,
-                        )
 
                         # Replace the status slot with a compact final banner
                         ui.set(
@@ -271,7 +224,7 @@ class QiboJob:
                             ),
                         )
                         live.refresh()
-                        return response, job_status
+                        return payload, job_status
 
                     time.sleep(seconds_between_checks)
 
@@ -283,7 +236,7 @@ class QiboJob:
             logger.info("📬 Job posted on %s with pid, %s", self.device, self.pid)
 
         while True:
-            job_status, qpos, etd = _fetch_snapshot()
+            job_status, qpos, etd, payload = _fetch_snapshot()
 
             # controlled, non-spam logging (prints each status once; PENDING upgraded once)
             last_status, printed_pending_with_info = log_status_non_tty(
@@ -298,12 +251,7 @@ class QiboJob:
             if job_status in (QiboJobStatus.SUCCESS, QiboJobStatus.ERROR):
                 if verbose:
                     logger.info("Job COMPLETED")
-                response = QiboApiRequest.get(
-                    self.base_url + f"/api/jobs/{self.pid}/download/",
-                    headers=self.headers,
-                    timeout=constants.TIMEOUT,
-                )
-                return response, job_status
+                return payload, job_status
 
             time.sleep(seconds_between_checks)
 

--- a/tests/test_qibo_job.py
+++ b/tests/test_qibo_job.py
@@ -5,6 +5,7 @@ import responses
 
 from qibo_client import QiboJobStatus, exceptions, qibo_job
 
+
 @pytest.mark.parametrize(
     "status, expected_result",
     [
@@ -21,7 +22,6 @@ from qibo_client import QiboJobStatus, exceptions, qibo_job
 def test_convert_str_to_job_status(status, expected_result):
     result = qibo_job.convert_str_to_job_status(status)
     assert result == expected_result
-
 
 
 FAKE_PID = "fakePid"

--- a/tests/test_qibo_job.py
+++ b/tests/test_qibo_job.py
@@ -1,17 +1,9 @@
-import tarfile
-from contextlib import contextmanager
-from pathlib import Path
-
 import fixs
 import jsf
 import pytest
 import responses
-import utils_test_qibo_client as utils
 
 from qibo_client import QiboJobStatus, exceptions, qibo_job
-
-ARCHIVE_NAME = "file.tar.gz"
-
 
 @pytest.mark.parametrize(
     "status, expected_result",
@@ -30,116 +22,6 @@ def test_convert_str_to_job_status(status, expected_result):
     result = qibo_job.convert_str_to_job_status(status)
     assert result == expected_result
 
-
-@pytest.fixture
-def archive_path(monkeypatch, tmp_path: Path):
-    archive_path = tmp_path / ARCHIVE_NAME
-
-    @contextmanager
-    def mock_named_tmp(delete: bool = False):
-        io_stream = archive_path.open("wb")
-        try:
-            yield io_stream
-        finally:
-            io_stream.close()
-
-    monkeypatch.setattr(
-        "qibo_client.qibo_job.tempfile.NamedTemporaryFile", mock_named_tmp
-    )
-    return archive_path
-
-
-def test__write_stream_to_tmp_file_with_simple_text_stream(
-    archive_path, tmp_path: Path
-):
-    """
-    The test contains the following checks:
-
-    - a new temporary file is created to a specific direction
-    - the content of the temporary file contains equals the one given
-    """
-    stream = [b"line1\n", b"line2\n"]
-
-    assert not archive_path.is_file()
-
-    result_path = qibo_job._write_stream_to_tmp_file(stream)
-
-    assert result_path == archive_path
-    assert result_path.is_file()
-    assert result_path.read_bytes() == b"".join(stream)
-
-
-def test__write_stream_to_tmp_file_with_archive(archive_path: Path):
-    """
-    The test contains the following checks:
-
-    - a new temporary archive is created to a specific direction
-    - load the archive in memory and check that the members and the contents
-    match with the expected ones
-    """
-    stream, members, members_contents = utils.get_in_memory_fake_archive_stream()
-
-    assert not archive_path.is_file()
-
-    result_path = qibo_job._write_stream_to_tmp_file(stream)
-
-    assert result_path == archive_path
-    assert result_path.is_file()
-
-    with tarfile.open(result_path, "r:gz") as archive:
-        result_members = sorted(archive.getnames())
-        assert result_members == members
-        for member, member_content in zip(members, members_contents):
-            with archive.extractfile(member) as result_member:
-                result_content = result_member.read()
-            assert result_content == member_content
-
-
-def test__extract_archive_to_folder_with_non_archive_input(tmp_path):
-    file_path = tmp_path / "file.txt"
-    file_path.write_text("test content")
-
-    with pytest.raises(tarfile.ReadError):
-        qibo_job._extract_archive_to_folder(file_path, tmp_path)
-
-
-def test__extract_archive_to_folder_with_success(monkeypatch, tmp_path: Path):
-    results_base_folder = tmp_path / "results"
-    results_base_folder.mkdir()
-    archive_path = tmp_path / ARCHIVE_NAME
-    monkeypatch.setattr(
-        "qibo_client.qibo_job.constants.RESULTS_BASE_FOLDER", results_base_folder
-    )
-    members, members_contents = utils.create_fake_archive(archive_path)
-
-    qibo_job._extract_archive_to_folder(archive_path, results_base_folder)
-
-    result_members = []
-    result_members_contents = []
-    for member_path in sorted(results_base_folder.iterdir()):
-        result_members.append(member_path.name)
-        result_members_contents.append(member_path.read_bytes())
-
-    assert result_members == members
-    assert result_members_contents == members_contents
-
-
-def test__save_and_unpack_stream_response_to_folder(monkeypatch, tmp_path: Path):
-    results_base_folder = tmp_path / "results"
-    results_base_folder.mkdir()
-    archive_path = tmp_path / ARCHIVE_NAME
-    monkeypatch.setattr(
-        "qibo_client.qibo_job.constants.RESULTS_BASE_FOLDER", results_base_folder
-    )
-
-    stream, _, _ = utils.get_in_memory_fake_archive_stream()
-
-    assert not archive_path.is_file()
-
-    qibo_job._save_and_unpack_stream_response_to_folder(stream, results_base_folder)
-
-    # the archive should have been removed
-    assert not archive_path.is_file()
 
 
 FAKE_PID = "fakePid"
@@ -318,72 +200,34 @@ class TestQiboJob:
         result = self.obj.success()
         assert result == expected_result
 
-    @responses.activate
-    def test_result_handles_tarfile_readerror(self, monkeypatch, refresh_job):
-        info_endpoint = FAKE_URL + f"/api/jobs/{FAKE_PID}/"
-        responses.add(
-            responses.GET,
-            info_endpoint,
-            json={"status": "success"},
-            status=200,
-        )
-
-        endpoint = FAKE_URL + f"/api/jobs/{FAKE_PID}/download/"
-        responses.add(responses.GET, endpoint, status=200)
-
-        def raise_tarfile_readerror(*args):
-            raise tarfile.ReadError()
-
+    def test_result_with_job_status_error(self, monkeypatch):
+        snapshot = {"stdout": "some output", "stderr": "some error"}
         monkeypatch.setattr(
-            "qibo_client.qibo_job._save_and_unpack_stream_response_to_folder",
-            raise_tarfile_readerror,
+            self.obj,
+            "_wait_for_response_to_get_request",
+            lambda *args, **kwargs: (snapshot, QiboJobStatus.ERROR),
         )
         result = self.obj.result()
         assert result is None
 
-    @responses.activate
-    def test_result_with_job_status_error(self, monkeypatch, refresh_job):
-        endpoint = FAKE_URL + f"/api/jobs/{FAKE_PID}/download/"
-        responses.add(responses.GET, endpoint, status=200)
+    def test_result_with_job_status_success(self, monkeypatch):
+        class FakeCircuit:
+            measurements = []
+            nqubits = 3
 
-        info_endpoint = FAKE_URL + f"/api/jobs/{FAKE_PID}/"
-        response_json = jsf.JSF(fixs.JOB_SCHEMA).generate()
-        response_json["status"] = "error"
-        responses.add(
-            responses.GET,
-            info_endpoint,
-            json=response_json,
-            status=200,
-        )
-
+        snapshot = {"circuit": {"some": "dict"}, "frequencies": {"000": 100}}
         monkeypatch.setattr(
-            "qibo_client.qibo_job._save_and_unpack_stream_response_to_folder",
-            lambda *args: "ok",
+            self.obj,
+            "_wait_for_response_to_get_request",
+            lambda *args, **kwargs: (snapshot, QiboJobStatus.SUCCESS),
         )
-        result = self.obj.result()
-        assert result is None
-
-    @responses.activate
-    def test_result_with_job_status_success(self, monkeypatch, refresh_job):
-        endpoint = FAKE_URL + f"/api/jobs/{FAKE_PID}/download/"
-        responses.add(responses.GET, endpoint, status=200)
-
-        info_endpoint = FAKE_URL + f"/api/jobs/{FAKE_PID}/"
-        responses.add(
-            responses.GET,
-            info_endpoint,
-            json={"status": "success"},
-            status=200,
-        )
-
         monkeypatch.setattr(
-            "qibo_client.qibo_job._save_and_unpack_stream_response_to_folder",
-            lambda *args: "ok",
+            "qibo_client.qibo_job.qibo.Circuit.from_dict",
+            lambda x: FakeCircuit(),
         )
-
         monkeypatch.setattr(
-            "qibo_client.qibo_job.qibo.result.load_result",
-            lambda x: FAKE_RESULT,
+            "qibo_client.qibo_job.qibo.result.MeasurementOutcomes.from_frequencies",
+            lambda *args, **kwargs: FAKE_RESULT,
         )
         result = self.obj.result()
         assert result == FAKE_RESULT
@@ -413,27 +257,19 @@ class TestQiboJob:
                 json={"status": "running"},
             )
 
+        final_payload = {"status": status}
         responses.add(
             responses.GET,
             info_endpoint,
             status=200,
-            json={"status": status},
-        )
-
-        endpoint = FAKE_URL + f"/api/jobs/{FAKE_PID}/download/"
-        response_json = {"detail": "output"}
-        responses.add(
-            responses.GET,
-            endpoint,
-            json=response_json,
-            status=200,
+            json=final_payload,
         )
 
         response, job_status = self.obj._wait_for_response_to_get_request(1e-4, False)
 
         assert job_status == expected_job_status
-        assert response.json() == response_json
-        assert len(responses.calls) == 1 + failed_attempts + 1
+        assert response == final_payload
+        assert len(responses.calls) == 1 + failed_attempts
 
         # first call is to status
         assert responses.calls[0].request.url == info_endpoint


### PR DESCRIPTION
Poll the job endpoint until completion, then build a MeasurementOutcome directly from the circuit dict and frequencies returned by the snapshot, removing all tarball download, extraction and results.npy loading logic.